### PR TITLE
Move hardcoded constants to config structure

### DIFF
--- a/lib/protocol/config.js
+++ b/lib/protocol/config.js
@@ -1,0 +1,6 @@
+var Config = {
+    addressPrefix: 'STM',
+    chainId: '0000000000000000000000000000000000000000000000000000000000000000'
+};
+
+module.exports = Config;

--- a/lib/protocol/types/index.js
+++ b/lib/protocol/types/index.js
@@ -10,7 +10,7 @@ var Long = ByteBuffer.Long;
 
 var PublicKey = require("./key-public");
 var hash = require('./../signature/hash');
-var config = 'STM';
+var config = require('./../config');
 var Types = {};
 
 var HEX_DUMP = process.env.npm_config__graphene_serializer_hex_dump;
@@ -839,7 +839,7 @@ Types.public_key = {
     },
     toObject: function toObject(object, debug) {
         if (debug.use_default && object === undefined) {
-            return config.address_prefix + "859gxfnXyUriMgUeThh1fWv3oqcpLFyHa3TfFYC4PK2HqhToVM";
+            return config.addressPrefix + "859gxfnXyUriMgUeThh1fWv3oqcpLFyHa3TfFYC4PK2HqhToVM";
         }
         return object.toString();
     },

--- a/lib/protocol/types/key-public.js
+++ b/lib/protocol/types/key-public.js
@@ -3,7 +3,7 @@ var ecurve = require('ecurve');
 var secp256k1 = ecurve.getCurveByName('secp256k1');
 var base58 = require('bs58');
 var hash = require('./../signature/hash');
-var config = { address_prefix: 'STM' };
+var config = require('./../config');
 var assert = require('assert');
 
 var G = secp256k1.G;
@@ -47,7 +47,7 @@ var PublicKey = function () {
     };
 
     PublicKey.prototype.toString = function toString() {
-        var address_prefix = arguments.length <= 0 || arguments[0] === undefined ? config.address_prefix : arguments[0];
+        var address_prefix = arguments.length <= 0 || arguments[0] === undefined ? config.addressPrefix : arguments[0];
 
         return this.toPublicKeyString(address_prefix);
     };
@@ -57,7 +57,7 @@ var PublicKey = function () {
         {return} string
     */
     PublicKey.prototype.toPublicKeyString = function toPublicKeyString() {
-        var address_prefix = arguments.length <= 0 || arguments[0] === undefined ? config.address_prefix : arguments[0];
+        var address_prefix = arguments.length <= 0 || arguments[0] === undefined ? config.addressPrefix : arguments[0];
 
         if (this.pubdata) return address_prefix + this.pubdata;
         var pub_buf = this.toBuffer();
@@ -74,10 +74,10 @@ var PublicKey = function () {
         @deprecated fromPublicKeyString (use fromString instead)
     */
     PublicKey.fromString = function fromString(public_key) {
-        var address_prefix = arguments.length <= 1 || arguments[1] === undefined ? config.address_prefix : arguments[1];
+        var address_prefix = arguments.length <= 1 || arguments[1] === undefined ? config.addressPrefix : arguments[1];
 
         try {
-            return PublicKey.fromStringOrThrow(public_key, address_prefix);
+            return PublicKey.fromStringOrThrow(public_key, addressPrefix);
         } catch (e) {
             return null;
         }
@@ -90,7 +90,7 @@ var PublicKey = function () {
         @return PublicKey
     */
     PublicKey.fromStringOrThrow = function fromStringOrThrow(public_key) {
-        var address_prefix = arguments.length <= 1 || arguments[1] === undefined ? config.address_prefix : arguments[1];
+        var address_prefix = arguments.length <= 1 || arguments[1] === undefined ? config.addressPrefix : arguments[1];
 
         var prefix = public_key.slice(0, address_prefix.length);
         assert.equal(address_prefix, prefix, 'Expecting key to begin with ' + address_prefix + ', instead got ' + prefix);
@@ -106,7 +106,7 @@ var PublicKey = function () {
     };
 
     PublicKey.prototype.toAddressString = function toAddressString() {
-        var address_prefix = arguments.length <= 0 || arguments[0] === undefined ? config.address_prefix : arguments[0];
+        var address_prefix = arguments.length <= 0 || arguments[0] === undefined ? config.addressPrefix : arguments[0];
 
         var pub_buf = this.toBuffer();
         var pub_sha = hash.sha512(pub_buf);

--- a/lib/steemauth.js
+++ b/lib/steemauth.js
@@ -5,11 +5,12 @@ var bigi = require('bigi'),
 	Point = ecurve.Point,
 	secp256k1 = ecurve.getCurveByName('secp256k1'),
 
+	config = require('./protocol/config')
 	operations = require('./protocol/operations'),
 	Signature = require('./protocol/signature'),
 	KeyPrivate = require('./protocol/types/key-private');
 
-var Auth = {};
+var Auth = { config: config };
 var transaction = operations.transaction;
 var signed_transaction = operations.signed_transaction;
 
@@ -40,7 +41,7 @@ Auth.generateKeys = function (name, password, roles) {
 		var pubBuf = point.getEncoded(toPubKey.compressed);
 		var checksum = crypto.createHash('rmd160').update(pubBuf).digest();
 		var addy = Buffer.concat([pubBuf, checksum.slice(0, 4)]);
-		pubKeys[role] = 'STM' + bs58.encode(addy);
+		pubKeys[role] = config.addressPrefix + bs58.encode(addy);
 	});
 	return pubKeys;
 };
@@ -97,7 +98,7 @@ Auth.signTransaction = function (trx, keys) {
 		signatures = [].concat(trx.signatures);
 	}
 
-	var cid = new Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex');
+	var cid = new Buffer(config.chainId, 'hex');
 	var buf = transaction.toBuffer(trx);
 
 	for (var key in keys) {


### PR DESCRIPTION
Hello. Could you look on suggesting changes. Idea is move hardcoded constants to config structure to support other STEEM-like blockchains (eg. golos).

I have very small experience with nodejs (and js) - so you give your review or maybe direction how to do it in best way..

One thing that I don't like is that steemauth works like singleton. So it's not possible (in current versions of steemauth and steem-js) to work with 2 types of blockchains simultaneously (without crutches).

Another thing - it will be great if steem-js will setup steemauth by himself when it connected to node.

But these 2 things required a lot of refactoring right? I cannot estimate with my experience. 

Thank you.